### PR TITLE
58.0/profile model.java/makino

### DIFF
--- a/src/project/arzeit/controller/LoginServlet.java
+++ b/src/project/arzeit/controller/LoginServlet.java
@@ -7,7 +7,6 @@ import javax.servlet.*;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.*;
 
-import project.arzeit.database.DBController;
 import project.arzeit.database.DataSource;
 import project.arzeit.model.AuthCModel;
 import project.arzeit.model.User;

--- a/src/project/arzeit/controller/RegisterServlet.java
+++ b/src/project/arzeit/controller/RegisterServlet.java
@@ -28,7 +28,7 @@ public class RegisterServlet extends HttpServlet {
         ServletContext context = this.getServletContext();
         AuthCModel authC = new AuthCModel((DataSource)context.getAttribute("dataSource"));
 
-        int code = authC.register(request.getParameter("id"), request.getParameter("pass")); //登録してエラーコード返すだけ
+        int code = authC.register(request.getParameter("id"), request.getParameter("pass"), request.getParameter("name")); //登録してエラーコード返すだけ
 
         StringBuilder json = new StringBuilder("{ \"code\": \""); //コードをjsonデ返す
         json.append(code).append("\" }");

--- a/src/project/arzeit/controller/RegisterServlet.java
+++ b/src/project/arzeit/controller/RegisterServlet.java
@@ -7,10 +7,10 @@ import javax.servlet.*;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.*;
 
-import project.arzeit.database.DBController;
+
 import project.arzeit.database.DataSource;
 import project.arzeit.model.AuthCModel;
-import project.arzeit.model.User;
+
 
 /**
  * project/arzeit/register.htmlに対応するサーブレット

--- a/src/project/arzeit/database/DBController.java
+++ b/src/project/arzeit/database/DBController.java
@@ -126,19 +126,6 @@ public class DBController {
         int code = update(message);
         return code;
     }
-    
-    /**
-     * パスワードを変更する
-     * 
-     * @param id
-     * @param pass
-     * @return :int エラーコード
-     */
-    public int setPass(String id, String pass) {
-        String message = String.format("UPDATE login set pass='%s' WHERE id='%s'", pass, id);
-        int code = update(message);
-        return code;
-    }
 
     /**
      * 予定の設定

--- a/src/project/arzeit/database/DBController.java
+++ b/src/project/arzeit/database/DBController.java
@@ -2,9 +2,8 @@ package project.arzeit.database;
 
 import java.sql.*;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Map.Entry;
+
 
 /**
  * HikariCPを使ったデータプールのソース DB接続の根っこ
@@ -328,7 +327,7 @@ public class DBController {
             pstm = con.prepareStatement(String.format("SELECT pass FROM login WHERE id='%s'", id)); //id指定でパスを取ってくる
             ResultSet result = pstm.executeQuery(); // 送信
             if(result.next()) pass = result.getString("pass");
-            else code = 1;
+            else code = 3;
             
         } catch (SQLException e) {
 

--- a/src/project/arzeit/database/DBController.java
+++ b/src/project/arzeit/database/DBController.java
@@ -114,20 +114,19 @@ public class DBController {
         int code = update(message);
         return code;
     }
-    
+
     /**
-     * プロフィールを登録する
-     * 
+     * プロフィールを初期化するだけ
      * @param id
-     * @param name
+     * @param pass
      * @return :int エラーコード
      */
-    public int setProfile(String id, String name) {
-        String message = String.format("INSERT INTO profile VALUES ('%s', '%s')", id, name);
+    public int setProfile(String id) {
+        String message = String.format("INSERT INTO profile VALUES ('%s', 'NULL')", id);
         int code = update(message);
         return code;
     }
-
+    
     /**
      * パスワードを変更する
      * 
@@ -213,25 +212,6 @@ public class DBController {
     }
 
     /**
-     * ID指定してアカウント情報を更新する
-     * @param id 更新元id
-     * @param updateId 更新語id
-     * @param updatePass 更新後パス
-     * @return エラーコード
-     */
-    public int updateAccount(String id, String updateId, String updatePass) {
-        
-        StringBuilder sBuilder = new StringBuilder("UPDATE login SET id = '");
-        sBuilder.append(updateId)
-        .append("', pass= '").append(updatePass)
-        .append("' WHERE id = '").append(id)
-        .append("';");
-
-        int code = update(sBuilder.toString());//命令送る
-        return code;
-    }
-
-    /**
      * インデックス指定でスケジュールを更新する(一個)
      * @param s_id 更新するindex
      * @param updateTime 開始、終了時間のマップ
@@ -250,7 +230,7 @@ public class DBController {
         int code = update(sBuilder.toString());//命令送る
         return code;
     }
-    
+
     /**
      * インデックス指定でスケジュールを更新する(複数)
      * @param index 更新するindex
@@ -305,6 +285,43 @@ public class DBController {
         return code;
         
     }
+
+    /**
+     * idを更新する
+     * @param id
+     * @param updateId
+     * @return エラーコード
+     */
+    public int updateId(String id, String updateId) {
+        
+        StringBuilder sBuilder = new StringBuilder("UPDATE login SET id = '");
+        sBuilder.append(updateId)
+        .append("' WHERE id = '").append(id)
+        .append("';");
+
+        int code = update(sBuilder.toString());//命令送る
+        return code;
+        
+    }
+
+    /**
+     * passを更新する
+     * @param id
+     * @param updateId
+     * @return エラーコード
+     */
+    public int updatePass(String id, String pass) {
+        
+        StringBuilder sBuilder = new StringBuilder("UPDATE login SET pass = '");
+        sBuilder.append(pass)
+        .append("' WHERE id = '").append(id)
+        .append("';");
+
+        int code = update(sBuilder.toString());//命令送る
+        return code;
+        
+    }
+
 
     /**
      * パスワード取ってくる

--- a/src/project/arzeit/model/AuthCModel.java
+++ b/src/project/arzeit/model/AuthCModel.java
@@ -26,7 +26,9 @@ public class AuthCModel {
     public int register(String id, String pass) {
         int code = checkDuplicate(id); //重複チェック
 
-        if (code == 0) return db.setAccount(id, pass);
+        if (code == 0) {
+            if((code = db.setAccount(id, pass)) == 0) code = db.setProfile(id);
+        } 
 
         return code;
     }

--- a/src/project/arzeit/model/AuthCModel.java
+++ b/src/project/arzeit/model/AuthCModel.java
@@ -84,7 +84,7 @@ public class AuthCModel {
      * @return ステータスコード
      */
     public int setPass(String id, String pass) {
-        return db.setPass(id, pass);
+        return db.updatePass(id, pass);
     }
 
 }

--- a/src/project/arzeit/model/AuthCModel.java
+++ b/src/project/arzeit/model/AuthCModel.java
@@ -23,11 +23,12 @@ public class AuthCModel {
      * @param pass
      * @return 今のところエラーは直で書いててそれ帰ってくる 2:id重複
      */
-    public int register(String id, String pass) {
+    public int register(String id, String pass, String name) {
         int code = checkDuplicate(id); //重複チェック
 
         if (code == 0) {
             if((code = db.setAccount(id, pass)) == 0) code = db.setProfile(id);
+            if(code == 0) code = db.updateProfile(id, name);
         } 
 
         return code;

--- a/src/project/arzeit/model/AuthCModel.java
+++ b/src/project/arzeit/model/AuthCModel.java
@@ -24,13 +24,11 @@ public class AuthCModel {
      * @return 今のところエラーは直で書いててそれ帰ってくる 2:id重複
      */
     public int register(String id, String pass) {
-        int code = db.checkDuplicate(id); //重複チェック　合わなかったら2帰ってくる
+        int code = checkDuplicate(id); //重複チェック
 
-        if (code == 0) {
-            return db.setAccount(id, pass);
-        } else {
-            return code;
-        }
+        if (code == 0) return db.setAccount(id, pass);
+
+        return code;
     }
 
     /**
@@ -54,6 +52,39 @@ public class AuthCModel {
         } else {
             return result.getValue(); 
         }
+    }
+
+    /**
+     * idを更新する
+     * @param id
+     * @param updateId
+     * @return ステータスコード
+     */
+    public int setId(String id, String updateId) {
+        int code = checkDuplicate(id); //重複チェック
+        if(code == 0) code = db.updateId(id, updateId);
+        
+        return code;
+    }
+
+    /**
+     * id重複検査
+     * @param id
+     * @return エラーコード　被ってたら 2返す
+     */
+    public int checkDuplicate(String id) {
+        return db.checkDuplicate(id);
+    }
+
+    /**
+     * passを更新する
+     * 前のパスを認証してから実行するように修正必要
+     * @param id
+     * @param updateId
+     * @return ステータスコード
+     */
+    public int setPass(String id, String pass) {
+        return db.setPass(id, pass);
     }
 
 }

--- a/src/project/arzeit/model/ProfileModel.java
+++ b/src/project/arzeit/model/ProfileModel.java
@@ -1,0 +1,19 @@
+package project.arzeit.model;
+
+import java.util.AbstractMap.SimpleEntry;
+
+import project.arzeit.database.DBController;
+import project.arzeit.database.DataSource;
+
+/**
+ * 認証とか登録処理を行うプログラム モデル
+ * @author Minoru Makino
+ */
+public class ProfileModel {
+
+    private DBController db;
+
+    public ProfileModel(DataSource ds) {
+        db = new DBController(ds);
+    }
+}

--- a/src/project/arzeit/model/ProfileModel.java
+++ b/src/project/arzeit/model/ProfileModel.java
@@ -6,7 +6,8 @@ import project.arzeit.database.DBController;
 import project.arzeit.database.DataSource;
 
 /**
- * 認証とか登録処理を行うプログラム モデル
+ * プロフィールを更新したり設定したりするモデル
+ * いまのところニックネームだけ
  * @author Minoru Makino
  */
 public class ProfileModel {
@@ -16,4 +17,13 @@ public class ProfileModel {
     public ProfileModel(DataSource ds) {
         db = new DBController(ds);
     }
+
+    public int setName(String id, String name) {
+        return db.updateProfile(id, name);
+    }
+
+    public SimpleEntry<String, Integer> getName(String id, String name) {
+        return db.getName(id);
+    }
+
 }

--- a/src/project/arzeit/model/ScheduleModel.java
+++ b/src/project/arzeit/model/ScheduleModel.java
@@ -3,8 +3,6 @@ package project.arzeit.model;
 import java.util.ArrayList;
 import java.util.AbstractMap.SimpleEntry;
 
-import com.mysql.cj.x.protobuf.MysqlxDatatypes.Array;
-
 import project.arzeit.database.DBController;
 import project.arzeit.database.DataSource;
 

--- a/src/project/test/AuthCModelTest.java
+++ b/src/project/test/AuthCModelTest.java
@@ -55,8 +55,8 @@ public class AuthCModelTest {
 
         dc.setAccount("test3", "pass3"); //重複させるために余分にアカウント作る
 
-        result1 = model.register("test2", "pass2");
-        result2 = model.register("test3", "pass3");
+        result1 = model.register("test2", "pass2", "namae");
+        result2 = model.register("test3", "pass3", "namae2");
 
         dc.deleteAccount("test2");
         dc.deleteAccount("test3");

--- a/src/project/test/DBControllerTest.java
+++ b/src/project/test/DBControllerTest.java
@@ -3,7 +3,6 @@ package project.test;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.AbstractMap.SimpleEntry;
 
 import org.junit.*;
@@ -350,7 +349,6 @@ public class DBControllerTest {
         // 設定するアカウント
         String id = "testAccount";
         String pass = "testPass";
-        String name = "namae";
         SimpleEntry<String, Integer> result;
 
         // 更新するアカウント

--- a/src/project/test/DBControllerTest.java
+++ b/src/project/test/DBControllerTest.java
@@ -205,7 +205,8 @@ public class DBControllerTest {
         String expectedPass = "testPass2";
 
         System.out.println(dcon.setAccount(id, pass));
-        System.out.println(dcon.updateAccount(id, updateId, updatePass));
+        System.out.println(dcon.updateId(id, updateId));
+        System.out.println(dcon.updatePass(updateId, updatePass));
 
         result = dcon.getPass(expectedID);
         System.out.println(result.getKey());
@@ -357,7 +358,7 @@ public class DBControllerTest {
 
 
         System.out.println(dcon.setAccount(id, pass));
-        System.out.println(dcon.setProfile(id, name));
+        System.out.println(dcon.setProfile(id));
 
         result = dcon.getName(id);
         System.out.println(result.getKey());

--- a/src/project/test/ScheduleModelTest.java
+++ b/src/project/test/ScheduleModelTest.java
@@ -5,16 +5,12 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.AbstractMap.SimpleEntry;
 
-import com.mysql.cj.xdevapi.JsonArray;
-import com.mysql.cj.xdevapi.JsonParser;
-
 import org.junit.*;
-import org.eclipse.jetty.util.ajax.JSON;
 import org.json.*;
 
 import project.arzeit.database.DBController;
 import project.arzeit.database.DataSource;
-import project.arzeit.model.AuthCModel;
+
 import project.arzeit.model.ScheduleModel;
 
 


### PR DESCRIPTION
#58 
- idとpassを更新するメソッドを分けた
- idとpassの更新は認証処理するモデルに実装するようにした(ハッシュ化があるため)
- DB関係のメソッドに冗長があったので解消
- プロフィールのデータを処理するモデルの作成（いまの所名前だけ
- 他いらんimport消した
- 単体テストを変更に伴って更新